### PR TITLE
Fix Bubblegum LoRA tag lookup

### DIFF
--- a/AIProject.py
+++ b/AIProject.py
@@ -125,7 +125,12 @@ def ensure_bubblegum_tags_file() -> None:
         print(f"[LoRA] Loading registry from {LORA_REGISTRY_PATH}")
         with open(LORA_REGISTRY_PATH, "r", encoding="utf-8") as f:
             registry = json.load(f)
-        tags = registry.get(BUBBLEGUM_LORA_NAME, {}).get("tags", [])
+        # Some registry formats nest entries under a top-level "loras" key.
+        if isinstance(registry, dict):
+            loras = registry.get("loras", registry)
+        else:
+            loras = {}
+        tags = loras.get(BUBBLEGUM_LORA_NAME, {}).get("tags", [])
         print(f"[LoRA] Found {len(tags)} tags for {BUBBLEGUM_LORA_NAME}")
         if not tags:
             print("[LoRA] No tags found; skipping file creation.")


### PR DESCRIPTION
## Summary
- Handle lora_registry.json files that wrap entries under a top-level `loras` key
- Prevent Bubblegum tag generation from being skipped when registry uses nested structure

## Testing
- `python -m py_compile AIProject.py`
- `pip install openai` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a993c9f664832bbfc25703c855777e