### PR TITLE
Remove skin_fur category and add dynamic tag prompts

### DIFF
--- a/extra_tags.json
+++ b/extra_tags.json
@@ -36,8 +36,6 @@
   "up_clothes": [],
   "bottom_clothes": [],
   "accessories": [],
-  "specific_body_parts": [],
-  "skin_fur": [],
   "position_sex_position": [
     "Standing neutral arms at sides",
     "Standing one hand on hip",


### PR DESCRIPTION
## Summary
- drop `skin_fur` tag category from code and extra tag data
- generate tag selection instructions dynamically based on available categories

## Testing
- `python -m py_compile AIProject.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab5920ab58832bb62991ac79839dce